### PR TITLE
Resolved the screenshot redirect

### DIFF
--- a/data/gbrainy.appdata.xml.in
+++ b/data/gbrainy.appdata.xml.in
@@ -15,7 +15,7 @@
     </_p>
   </description>
   <screenshots>
-      <screenshot type="default">http://gent.softcatala.org/jmas/gbrainy/gbrainy-screenshot-appdata.png</screenshot>
+      <screenshot type="default">https://gent.softcatala.org/jmas/gbrainy/gbrainy-screenshot-appdata.png</screenshot>
   </screenshots>
   <url type="homepage">https://wiki.gnome.org/action/show/Apps/gbrainy/</url>
   <updatecontact>jmas_at_softcatala_dot_org</updatecontact>


### PR DESCRIPTION
This will fix the broken link at https://software.opensuse.org/package/gbrainy

Actually a workaround for https://github.com/openSUSE/software-o-o/issues/82.